### PR TITLE
Fixed problem with newnode not clearing the value of a reused node, and DeleteCIDR sometimes deleting a whole range and sometimes not

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -394,6 +394,7 @@ func (tree *Tree) newnode() (p *node) {
 		p.right = nil
 		p.parent = nil
 		p.left = nil
+		p.value = nil
 		return p
 	}
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -112,6 +112,26 @@ func TestTree(t *testing.T) {
 
 }
 
+func TestRegression(t *testing.T) {
+	tr := NewTree(0)
+	if tr == nil || tr.root == nil {
+		t.Error("Did not create tree properly")
+	}
+
+	tr.AddCIDR("1.1.1.0/24", 1)
+	
+	tr.DeleteCIDR("1.1.1.0/24")
+	tr.AddCIDR("1.1.1.0/25", 2)
+
+	// inside old range, outside new range
+	inf, err := tr.FindCIDR("1.1.1.128")
+	if err != nil {
+		t.Error(err)
+	} else if inf != nil {
+		t.Errorf("Wrong value, expected nil, got %v", inf)
+	}
+}
+
 func TestTree6(t *testing.T) {
 	tr := NewTree(0)
 	if tr == nil || tr.root == nil {


### PR DESCRIPTION
See [https://play.golang.org/p/blvOqFrwxt](https://play.golang.org/p/blvOqFrwxt). A reused node that has not cleared the value may cause deleted data to reappear in the radix tree.

Also, see [https://play.golang.org/p/R3QuCjRu_o](https://play.golang.org/p/R3QuCjRu_o). DeleteCIDR would delete the whole range if the node corresponding to the CIDR only had 1 branch, but would not delete the whole range if the node had 2 branches, which is completely arbitrary. I fixed this, added a DeleteWholeRangeCIDR function, and added a SetCIDR function so it doesn't return ErrNodeBusy if you want to overwrite existing values, and added the corresponding tests.
